### PR TITLE
Create a logback appender for logentries

### DIFF
--- a/src/com/logentries/logback/LogentriesAppender.java
+++ b/src/com/logentries/logback/LogentriesAppender.java
@@ -402,10 +402,8 @@ public class LogentriesAppender extends AppenderBase<ILoggingEvent> {
       StackTraceElement[] stack = event.getCallerData();
       int len = stack.length;
       for (int i = 0; i < len; i++) {
-        formattedEvent += "\tat " + stack[i].getClassName() + "." + stack[i].getMethodName()
+        formattedEvent += "\u2028\tat " + stack[i].getClassName() + "." + stack[i].getMethodName()
             + "(" + stack[i].getFileName() + ":" + stack[i].getLineNumber() + ")";
-        if (i < len - 1)
-          formattedEvent += "\u2028";
       }
     }
 


### PR DESCRIPTION
This is mostly copied from the log4j version. I'm not sure if that's the best way of doing things. However, using this with my Play Framework app I'm finally able to have logentries behave normally with respect to new lines. I haven't tested it extensively. In particular I'd be interested to see if it works with nested stack traces (i.e. "Caused by:" in the stack trace).
