### PR TITLE
Fixed LogEntriesAppender for logback

### DIFF
--- a/src/main/java/com/logentries/logback/LogentriesAppender.java
+++ b/src/main/java/com/logentries/logback/LogentriesAppender.java
@@ -155,21 +155,8 @@ public class LogentriesAppender extends AppenderBase<ILoggingEvent> {
 	 */
 	@Override
 	protected void append(ILoggingEvent event) {
-		
 		// Render the event according to layout
 		String formattedEvent = layout.doLayout(event);
-
-		// Append stack trace if present
-		if (event.getThrowableProxy() != null) {
-			StackTraceElement[] stack = event.getCallerData();
-			int len = stack.length;
-			for (int i = 0; i < len; i++) {
-				formattedEvent += "\u2028\tat " + stack[i].getClassName() + "." + stack[i].getMethodName()
-						+ "(" + stack[i].getFileName() + ":" + stack[i].getLineNumber() + ")";
-			}
-		}
-
-		// Prepare to be queued
 		this.le_async.addLineToQueue(formattedEvent);
 	}
 

--- a/src/test/java/com/logentries/logback/LogentriesAppenderTest.java
+++ b/src/test/java/com/logentries/logback/LogentriesAppenderTest.java
@@ -1,10 +1,12 @@
 package com.logentries.logback;
 
-import static org.junit.Assert.assertEquals;
-
+import ch.qos.logback.classic.LoggerContext;
+import com.logentries.net.AsyncLogger;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.junit.Assert.assertEquals;
 
 public class LogentriesAppenderTest {
 	
@@ -15,21 +17,47 @@ public class LogentriesAppenderTest {
 	private static final String location = "some location";
 	private static final String accountKey = "account key";
 	private static final String facility = "DAEMON";
+
+    public  static LogentriesAppender newAppender(){
+        LogentriesAppender le = new LogentriesAppender();
+        le.setHttpPut(true);
+        le.setToken(token);
+        le.setLocation(location);
+        le.setKey(accountKey);
+        le.setSsl(true);
+        le.setFacility(facility);
+        return le;
+    }
+
+
 	
 	@Test
 	public void setterTests() {
-		LogentriesAppender le = new LogentriesAppender();
-		le.setHttpPut(true);
-		le.setToken(token);
-		le.setLocation(location);
-		le.setKey(accountKey);
-		le.setSsl(true);
-		le.setFacility(facility);
+		LogentriesAppender le = newAppender();
 		assertEquals(le.le_async.getToken(),token);
 		assertEquals(le.le_async.getHttpPut(),true);
 		assertEquals(le.le_async.getKey(),accountKey);
 		assertEquals(le.le_async.getLocation(),location);
 		assertEquals(le.le_async.getSsl(),true);		 
-	}		
+	}
+
+
+    public void correctStackTraceTest() throws Exception{
+        LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
+        ch.qos.logback.classic.Logger logger = loggerContext.getLogger(LogentriesAppenderTest.class);
+//        LogentriesAppender appender = newAppender();
+        LogentriesAppender appender = new LogentriesAppender();
+        //appender.setToken("7aaa");
+        appender.setFacility("USER");
+        AsyncLogger asyncLogger = appender.le_async;
+        logger.addAppender(appender);
+        appender.start();
+        asyncLogger.addLineToQueue("Only to initialize the client");
+        Exception exception = new Exception("This is a test",new NullPointerException("Something is null"));
+        log.error("An error has occurred for {} " , "no idea",exception );
+        Thread.sleep(1500);
+
+        System.out.println("Error");
+    }
 }
 


### PR DESCRIPTION
The correct stack trace to show is the one of the exception and not the one of the caller. The layout automatically does that
