### PR TITLE
Reverted call to loglog to System.err so logback users can also use the debug command.

### DIFF
--- a/src/main/java/com/logentries/net/AsyncLogger.java
+++ b/src/main/java/com/logentries/net/AsyncLogger.java
@@ -46,11 +46,11 @@ public class AsyncLogger {
 	/** Platform dependent line separator to check for. Supported in Java 1.6+ */
 	private static final String LINE_SEP = System.getProperty("line_separator", "\n");
 	/** Error message displayed when invalid API key is detected. */
-	private static final String INVALID_TOKEN = LINE_SEP+LINE_SEP+"It appears your LOGENTRIES_TOKEN parameter in log4j.xml is incorrect!"+LINE_SEP+LINE_SEP;
+	private static final String INVALID_TOKEN = "\n\nIt appears your LOGENTRIES_TOKEN parameter in log4j.xml is incorrect!\n\n";
 	/** Key Value for Token Environment Variable. */
 	private static final String CONFIG_TOKEN = "LOGENTRIES_TOKEN";
 	/** Error message displayed when queue overflow occurs */
-	private static final String QUEUE_OVERFLOW = LINE_SEP+LINE_SEP+"Logentries Buffer Queue Overflow. Message Dropped!"+LINE_SEP+LINE_SEP;
+	private static final String QUEUE_OVERFLOW = "\n\nLogentries Buffer Queue Overflow. Message Dropped!\n\n";
 	/** Identifier for this client library */
 	private static final String LIBRARY_ID = "###J01### - Library initialised";
 
@@ -74,8 +74,6 @@ public class AsyncLogger {
 	boolean local = false;
 	/** Indicator if the socket appender has been started. */
 	boolean started = false;
-	/**  Will be true if static block finds log4j classes */
-	private static boolean log4jPresent;
 
 	/** Asynchronous socket appender. */
 	SocketAppender appender;
@@ -475,7 +473,7 @@ public class AsyncLogger {
 			} catch (InterruptedException e) {
 				// We got interrupted, stop
 				dbg( "Asynchronous socket writer interrupted");
-				dbg("Queue Size had "+queue.size()+" lines left in it");
+				dbg("Queue had "+queue.size()+" lines left in it");
 			}
 
 			closeConnection();


### PR DESCRIPTION
I've removed reference to loglog.error as this was stopping logback users from seeing debug messages as they did not have the log4j dependancy and loglog is also not in the slf4j adapters.
From log4j source, the call to loglog.error just prints to System.err anyway
http://grepcode.com/file/repo1.maven.org/maven2/log4j/log4j/1.2.17/org/apache/log4j/helpers/LogLog.java?av=f#124

Additionally I've Also Changed INVALID_TOKEN and QUEUE_OVERFLOW to use LINE_SEP instead of unix carriage returns.

And Added dbg message to display queue size when socket writer was interrrupted
