### PR TITLE
Bump up Log4J2 logger version to 2.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,6 +4,7 @@
 	<properties>
 		<additionalparam>-Xdoclint:none</additionalparam>
         <jackson2Version>2.4.2</jackson2Version>
+        <log4j2Version>2.7</log4j2Version>
     </properties>
 
     <parent>
@@ -148,13 +149,13 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.1</version>
+            <version>${log4j2Version}</version>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.1</version>
+            <version>${log4j2Version}</version>
             <optional>true</optional>
         </dependency>
         <!-- Jackson 2 start -->


### PR DESCRIPTION
Bump up Log4J2 logger version to 2.7 and refactor to be compatible with new concept of LoggerContext.

This is to fix blocker bug https://github.com/rapid7/le_java/issues/54