### PR TITLE
Add dependency and bump the version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,6 +5,7 @@
 		<additionalparam>-Xdoclint:none</additionalparam>
         <jackson2Version>2.4.2</jackson2Version>
         <log4j2Version>2.7</log4j2Version>
+        <disruptorVersion>3.3.6</disruptorVersion>
     </properties>
 
     <parent>
@@ -18,7 +19,7 @@
     <artifactId>logentries-appender</artifactId>
     <packaging>jar</packaging>
     <name>Logentries Appender</name>
-    <version>1.1.36-SNAPSHOT</version>
+    <version>1.1.37-SNAPSHOT</version>
     <description>Contains logback, log4j, and log4j2 appenders that will send log data to Logentries</description>
     <url>https://github.com/logentries/le_java</url>
     <licenses>
@@ -145,6 +146,11 @@
             <artifactId>log4j</artifactId>
             <version>1.2.17</version>
             <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>com.lmax</groupId>
+            <artifactId>disruptor</artifactId>
+            <version>${disruptorVersion}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>


### PR DESCRIPTION
Added disruptor library as it was a requirement for log4j 2.7 along with the changes in this PR: https://github.com/rapid7/le_java/pull/56, otherwise we get ClassNotFoundException:

java.lang.NoClassDefFoundError: com/lmax/disruptor/EventTranslatorVararg
	at java.lang.ClassLoader.defineClass1(Native Method)
	at java.lang.ClassLoader.defineClass(ClassLoader.java:763)
	at java.security.SecureClassLoader.defineClass(SecureClassLoader.java:142)
	at java.net.URLClassLoader.defineClass(URLClassLoader.java:467)
	at java.net.URLClassLoader.access$100(URLClassLoader.java:73)
	at java.net.URLClassLoader$1.run(URLClassLoader.java:368)
	at java.net.URLClassLoader$1.run(URLClassLoader.java:362)
	at java.security.AccessController.doPrivileged(Native Method)
	at java.net.URLClassLoader.findClass(URLClassLoader.java:361)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:331)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
	at com.logentries.log4j2.LogentriesManager$LogentriesManagerFactory.createManager(LogentriesManager.java:30)
	at com.logentries.log4j2.LogentriesManager$LogentriesManagerFactory.createManager(LogentriesManager.java:25)
	at org.apache.logging.log4j.core.appender.AbstractManager.getManager(AbstractManager.java:112)
	at com.logentries.log4j2.LogentriesManager.getManager(LogentriesManager.java:22)
	at com.logentries.log4j2.LogentriesAppender.createAppender(LogentriesAppender.java:67)
	... 24 more
Caused by: java.lang.ClassNotFoundException: com.lmax.disruptor.EventTranslatorVararg
	at java.net.URLClassLoader.findClass(URLClassLoader.java:381)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:331)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
	... 41 more

