### PR TITLE
LOG-8921 not enforcing asynclogger anymore

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -151,6 +151,7 @@
             <groupId>com.lmax</groupId>
             <artifactId>disruptor</artifactId>
             <version>${disruptorVersion}</version>
+           <optional>true</optional> 
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>

--- a/src/main/java/com/logentries/log4j2/LogentriesManager.java
+++ b/src/main/java/com/logentries/log4j2/LogentriesManager.java
@@ -27,7 +27,7 @@ public class LogentriesManager extends AbstractManager
         @Override
         public LogentriesManager createManager(String name, FactoryData data)
         {
-            return new LogentriesManager(new AsyncLoggerContext(name), name, data);
+            return new LogentriesManager(new LoggerContext(name), name, data);
         }
     }
 
@@ -64,7 +64,7 @@ public class LogentriesManager extends AbstractManager
     {
         asyncLogger.close();
         LOGGER.debug("AsyncLogger closed.");
-        return super.releaseSub(timeout, timeUnit);
+        return true;
     }
 
     public void writeLine(String line)

--- a/src/main/java/com/logentries/net/AsyncLogger.java
+++ b/src/main/java/com/logentries/net/AsyncLogger.java
@@ -420,8 +420,9 @@ public class AsyncLogger {
 
 	private void addLineToQueue (String line, int limit) {
 		if (limit == 0) {
-            dbg("Message longer than " + RECURSION_LIMIT);
-            return; }
+            dbg("Message longer than " + RECURSION_LIMIT * LOG_LENGTH_LIMIT);
+            return;
+		}
 
 		//// Check credentials only if logs are sent to LE directly.
 		// Check that we have all parameters set and socket appender running.

--- a/src/test/java/com/logentries/log4j2/Log4J2Test.java
+++ b/src/test/java/com/logentries/log4j2/Log4J2Test.java
@@ -4,6 +4,8 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.Configurator;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 /**
@@ -12,10 +14,21 @@ import org.junit.Test;
  */
 public class Log4J2Test
 {
+    private LoggerContext loggerContext;
+    
+    @Before
+    public void setUp() {
+        loggerContext = Configurator.initialize("test-log4j2", "log4j2-appender-test.xml");
+    }
+    
+    @After
+    public void tearDown() {
+        Configurator.shutdown(loggerContext);
+    }
+    
     @Test
     public void testLog4J2Appender() throws Exception
     {
-        LoggerContext loggerContext = Configurator.initialize("test-log4j2", "log4j2-appender-test.xml");
         Logger log = LogManager.getLogger("TEST-LOGGER");
         log.info("Hello there.");
         try
@@ -26,7 +39,11 @@ public class Log4J2Test
         {
             log.error("This is an error, with an exception: " + e, e);
         }
-        Thread.sleep(2000);
-        Configurator.shutdown(loggerContext);
+    }
+    
+    @Test
+    public void testLog4J2WithAsyncLogger() throws Exception {
+        Logger log = LogManager.getLogger("test-async-logger");
+        log.info("Test log line.");
     }
 }

--- a/src/test/resources/log4j2-appender-test.xml
+++ b/src/test/resources/log4j2-appender-test.xml
@@ -27,5 +27,8 @@
             <AppenderRef ref="Console"/>
             <AppenderRef ref="Logentries"/>
         </Root>
+        <AsyncLogger name="test-async-logger" level="INFO">
+            <AppenderRef ref="Logentries" />
+        </AsyncLogger>
     </Loggers>
 </Configuration>


### PR DESCRIPTION
This PR removes the enforcement of AsyncLogger on logger objects for log4j2. 
I will also update the wiki page after merging this with related version and dependency requirements with log4j2>=2.7 and log4j<2.7.