### PR TITLE
LOG-8797 fix for silently ignoring IOException on openConnection()

### DIFF
--- a/src/main/java/com/logentries/net/AsyncLogger.java
+++ b/src/main/java/com/logentries/net/AsyncLogger.java
@@ -505,22 +505,17 @@ public class AsyncLogger {
 		 * @throws IOException
 		 */
 		void openConnection() throws IOException {
-			try{
-				if(this.le_client == null){
-					this.le_client = new LogentriesClient(httpPut, ssl, useDataHub, dataHubAddr, dataHubPort);
-				}
+			if (this.le_client == null) {
+				this.le_client = new LogentriesClient(httpPut, ssl, useDataHub, dataHubAddr, dataHubPort);
+			}
 
-				this.le_client.connect();
+			this.le_client.connect();
 
-				if(httpPut){
-					final String f = "PUT /%s/hosts/%s/?realtime=1 HTTP/1.1\r\n\r\n";
-					final String header = String.format( f, key, location);
-					byte[] temp = header.getBytes( ASCII);
-					this.le_client.write( temp, 0, temp.length);
-				}
-
-			}catch(Exception e){
-
+			if (httpPut) {
+				final String f = "PUT /%s/hosts/%s/?realtime=1 HTTP/1.1\r\n\r\n";
+				final String header = String.format(f, key, location);
+				byte[] temp = header.getBytes(ASCII);
+				this.le_client.write(temp, 0, temp.length);
 			}
 		}
 
@@ -657,7 +652,8 @@ public class AsyncLogger {
 						try {
 							this.le_client.write( finalLine, 0, finalLine.length);
 						} catch (IOException e) {
-							// Reopen the lost connection
+                            dbg("Existing connection is lost, will try to reestablish.");
+                            // Reopen the lost connection
 							reopenConnection();
 							continue;
 						}

--- a/src/main/java/com/logentries/net/LogentriesClient.java
+++ b/src/main/java/com/logentries/net/LogentriesClient.java
@@ -1,122 +1,108 @@
 package com.logentries.net;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.net.Socket;
-import java.net.UnknownHostException;
-
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLSocketFactory;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.Socket;
 
 /**
  * Client for sending messages to Logentries via HTTP PUT or Token-Based Logging
  * Supports SSL/TLS
- * 
+ *
  * @author Mark Lacomber
- * 
  */
-public class LogentriesClient
-{
-	/*
-	 * Constants
-	 */
-	
-	/** Logentries API server address for Token-based input. */
-	private static final String LE_TOKEN_API = "data.logentries.com";
-	/** Logentries API server address for HTTP PUT input. */
-	private static final String LE_HTTP_API = "api.logentries.com";
-	/** Port number for HTTP PUT/Token TCP logging on Logentries server. */
-	private static final int LE_PORT = 80;
-	/** Port number for SSL HTTP PUT/TLS Token TCP logging on Logentries server. */
-	private static final int LE_SSL_PORT = 443;
+public class LogentriesClient {
+    /**
+     * Logentries API server address for Token-based input.
+     */
+    private static final String LE_TOKEN_API = "data.logentries.com";
+    /**
+     * Logentries API server address for HTTP PUT input.
+     */
+    private static final String LE_HTTP_API = "api.logentries.com";
+    /**
+     * Port number for HTTP PUT/Token TCP logging on Logentries server.
+     */
+    private static final int LE_PORT = 80;
+    /**
+     * Port number for SSL HTTP PUT/TLS Token TCP logging on Logentries server.
+     */
+    private static final int LE_SSL_PORT = 443;
 
-	private final SSLSocketFactory ssl_factory;
-	private boolean ssl_choice = false;
-	private boolean http_choice = false;
-	private Socket socket;
+    private final SSLSocketFactory ssl_factory;
+    private boolean ssl_choice = false;
+    private boolean http_choice = false;
+    private Socket socket;
     private OutputStream outputStream;
     private String dataHubServer = LE_TOKEN_API;
-	private int dataHubPort = LE_PORT;
-	private boolean useDataHub = false;
-	
-	public LogentriesClient(boolean httpPut, boolean ssl, boolean isUsingDataHub, String server, int port)
-	{
-		if(isUsingDataHub){
-			ssl_factory = null; // DataHub does not support input over SSL for now,
-			ssl_choice = false; // so SSL flag is ignored
-			useDataHub = true;
-			dataHubServer = server;
-			dataHubPort = port;
-		}
-		else{
-			ssl_factory = (SSLSocketFactory) SSLSocketFactory.getDefault();
-			ssl_choice = ssl;
-			http_choice = httpPut;
-		}
-	}
+    private int dataHubPort = LE_PORT;
+    private boolean useDataHub = false;
 
-	public int getPort()
-	{
-		if(useDataHub)
-		{
-			return dataHubPort;
-		}
-		else{
-			return ssl_choice ? LE_SSL_PORT : LE_PORT;
-		}
-	}
-
-	public String getAddress()
-	{
-		if(useDataHub)
-		{
-			return dataHubServer;
-		}
-		else{
-			return http_choice ? LE_HTTP_API : LE_TOKEN_API;
-		}
-	}
-	
-	public void connect() throws IOException
-	{
-		if(ssl_choice) {
-			if(http_choice)
-			{
-				SSLSocket s = (SSLSocket) ssl_factory.createSocket( getAddress(), getPort() );
-				s.startHandshake();
-				socket = s;
-			}else{
-				socket = ssl_factory.createSocket(getAddress(), getPort());
-			}
-		}else{
-			socket = new Socket( getAddress(), getPort() );
-		}
-
-		this.socket.setKeepAlive(true);
-		this.outputStream = socket.getOutputStream();
+    public LogentriesClient(boolean httpPut, boolean ssl, boolean isUsingDataHub, String server, int port) {
+        if (isUsingDataHub) {
+            ssl_factory = null; // DataHub does not support input over SSL for now,
+            ssl_choice = false; // so SSL flag is ignored
+            useDataHub = true;
+            dataHubServer = server;
+            dataHubPort = port;
+        } else {
+            ssl_factory = (SSLSocketFactory) SSLSocketFactory.getDefault();
+            ssl_choice = ssl;
+            http_choice = httpPut;
+        }
     }
-	
-	public void write(byte[] buffer, int offset, int length) throws IOException
-	{
-		if(this.outputStream == null) {
-			throw new IOException();
-		}
 
-		this.outputStream.write(buffer, offset, length);
-		this.outputStream.flush();
-	}
-	
-	public void close()
-	{
-		try{
-			if (this.socket != null)
-			{
-				this.socket.close();
-				this.socket = null;
-			}
-		}catch(Exception e){
-			
-		}
-	}
+    public int getPort() {
+        if (useDataHub) {
+            return dataHubPort;
+        } else {
+            return ssl_choice ? LE_SSL_PORT : LE_PORT;
+        }
+    }
+
+    public String getAddress() {
+        if (useDataHub) {
+            return dataHubServer;
+        } else {
+            return http_choice ? LE_HTTP_API : LE_TOKEN_API;
+        }
+    }
+
+    public void connect() throws IOException {
+        if (ssl_choice) {
+            if (http_choice) {
+                SSLSocket s = (SSLSocket) ssl_factory.createSocket(getAddress(), getPort());
+                s.startHandshake();
+                socket = s;
+            } else {
+                socket = ssl_factory.createSocket(getAddress(), getPort());
+            }
+        } else {
+            socket = new Socket(getAddress(), getPort());
+        }
+
+        this.socket.setKeepAlive(true);
+        this.outputStream = socket.getOutputStream();
+    }
+
+    public void write(byte[] buffer, int offset, int length) throws IOException {
+        if (this.outputStream == null) {
+            throw new IOException();
+        }
+
+        this.outputStream.write(buffer, offset, length);
+        this.outputStream.flush();
+    }
+
+    public void close() {
+        try {
+            if (this.socket != null) {
+                this.socket.close();
+                this.socket = null;
+            }
+        } catch (Exception e) {
+
+        }
+    }
 }

--- a/src/main/java/com/logentries/net/LogentriesClient.java
+++ b/src/main/java/com/logentries/net/LogentriesClient.java
@@ -1,6 +1,7 @@
 package com.logentries.net;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.Socket;
 import java.net.UnknownHostException;
@@ -30,12 +31,12 @@ public class LogentriesClient
 	/** Port number for SSL HTTP PUT/TLS Token TCP logging on Logentries server. */
 	private static final int LE_SSL_PORT = 443;
 
-	final SSLSocketFactory ssl_factory;
+	private final SSLSocketFactory ssl_factory;
 	private boolean ssl_choice = false;
 	private boolean http_choice = false;
 	private Socket socket;
-	private OutputStream stream;
-	private String dataHubServer = LE_TOKEN_API;
+    private OutputStream outputStream;
+    private String dataHubServer = LE_TOKEN_API;
 	private int dataHubPort = LE_PORT;
 	private boolean useDataHub = false;
 	
@@ -44,7 +45,7 @@ public class LogentriesClient
 		if(isUsingDataHub){
 			ssl_factory = null; // DataHub does not support input over SSL for now,
 			ssl_choice = false; // so SSL flag is ignored
-			useDataHub = isUsingDataHub;
+			useDataHub = true;
 			dataHubServer = server;
 			dataHubPort = port;
 		}
@@ -77,32 +78,33 @@ public class LogentriesClient
 		}
 	}
 	
-	public void connect() throws UnknownHostException, IOException
+	public void connect() throws IOException
 	{
 		if(ssl_choice) {
 			if(http_choice)
 			{
 				SSLSocket s = (SSLSocket) ssl_factory.createSocket( getAddress(), getPort() );
-				s.setTcpNoDelay( true);
 				s.startHandshake();
 				socket = s;
 			}else{
-				socket = SSLSocketFactory.getDefault().createSocket( getAddress(), getPort() );
+				socket = ssl_factory.createSocket(getAddress(), getPort());
 			}
 		}else{
 			socket = new Socket( getAddress(), getPort() );
 		}
 
-		this.stream = socket.getOutputStream();
-	}
+		this.socket.setKeepAlive(true);
+		this.outputStream = socket.getOutputStream();
+    }
 	
 	public void write(byte[] buffer, int offset, int length) throws IOException
 	{
-		if(this.stream == null){
+		if(this.outputStream == null) {
 			throw new IOException();
 		}
-		this.stream.write(buffer, offset, length);
-		this.stream.flush();
+
+		this.outputStream.write(buffer, offset, length);
+		this.outputStream.flush();
 	}
 	
 	public void close()


### PR DESCRIPTION
An attempt to fix broken logic in catching IOException raised in https://github.com/rapid7/le_java/issues/55 and adds debug lines. Additionally, enables tcp keepalive.

Also did some cleanup in LogentriesClient and fixed formatting.

This does not fix the problem with missing log lines sent with SSL connection. Still investigating it.